### PR TITLE
Minor fixes for installation_test.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 #  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Ignore all installation test data
+installation_test/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/installation_test.py
+++ b/installation_test.py
@@ -26,7 +26,7 @@ from romcomma import run
 from romcomma.test.utilities import sample
 
 
-BASE_PATH = Path('.\\installation_test')
+BASE_PATH = Path('installation_test')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* `BASE_PATH` still have double backslash, suggest removing it all together, there should be no need to add the current directory prefix `./`
* Added a rule in .gitgnore to ignore data files generated by `installation_test.py`